### PR TITLE
Add weapon collision check to prevent wall clipping

### DIFF
--- a/SystemLink/SystemLinkWeaponComponent.cpp
+++ b/SystemLink/SystemLinkWeaponComponent.cpp
@@ -152,3 +152,35 @@ FRotator USystemLinkWeaponComponent::CalculateWeaponSway(const float LookX, cons
 
 	return SwayRotation;
 }
+
+bool USystemLinkWeaponComponent::CheckWeaponBlocking(const FVector& CameraLocation, const FVector& CameraForwardVector, const bool bDebug)
+{
+	const FVector TraceStart = CameraLocation;
+	const FVector TraceEnd = TraceStart + (CameraForwardVector * WeaponBLockingTraceDistance);
+	constexpr float SphereRadius = 15.0f; // Adjust as needed
+
+	FCollisionQueryParams TraceParams(FName(TEXT("WeaponBlockTrace")), true, GetOwner());
+	TraceParams.bReturnPhysicalMaterial = false;
+	TraceParams.AddIgnoredActor(GetOwner());
+
+	FHitResult HitResult;
+	const bool bHit = GetWorld()->SweepSingleByChannel(
+		HitResult,
+		TraceStart,
+		TraceEnd,
+		FQuat::Identity,
+		ECC_Visibility,
+		FCollisionShape::MakeSphere(SphereRadius),
+		TraceParams
+	);
+
+#if WITH_EDITOR
+	if (bDebug)
+	{
+		DrawDebugSphere(GetWorld(), TraceEnd, SphereRadius, 12, bHit ? FColor::Red : FColor::Green, false, 1.0f);
+	}
+#endif
+
+	bIsWeaponBlocked = bHit;
+	return bIsWeaponBlocked;
+}

--- a/SystemLink/SystemLinkWeaponComponent.h
+++ b/SystemLink/SystemLinkWeaponComponent.h
@@ -69,7 +69,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Weapon Sway")
 	FRotator CalculateWeaponSway(float LookX, float LookY, float DeltaTime, float PlayerSpeed);
 
-
+	// Function to check if the weapon is blocked by a wall
+	UFUNCTION(BlueprintCallable, Category = "SystemLink|Weapon")
+	bool CheckWeaponBlocking(const FVector& CameraLocation, const FVector& CameraForwardVector, const bool bDebug = false);
+	
 protected:
 	/** Stores the last frame’s sway rotation */
 	FRotator SwayRotation;
@@ -81,4 +84,14 @@ protected:
 	// Default particle effect for impacts (assign in Blueprint)
 	UPROPERTY(EditDefaultsOnly, Category = "SystemLink|Shooting")
 	UNiagaraSystem* ImpactNiagaraEffect;
+
+	// The maximum distance at which the weapon will perform a blocking trace check to detect nearby obstacles.
+	// If an obstacle is detected within this range, the weapon will be considered "blocked," triggering animations
+	// or positional adjustments to prevent clipping through walls or objects. This value is adjustable in Blueprints.
+	UPROPERTY(EditDefaultsOnly, Category = "SystemLink|Shooting")
+	float WeaponBLockingTraceDistance = 30;
+
+private:
+	// Tracks if the weapon is blocked
+	bool bIsWeaponBlocked;
 };


### PR DESCRIPTION
### Description

This pull request introduces a weapon collision check to prevent weapons from clipping through walls or nearby objects. A trace-based method is implemented to detect obstructions, including configurable trace distance and a debug visualization option for easier testing and troubleshooting. This change enhances realism by ensuring weapons correctly interact with the environment.

### Checklist

- [ ] Code compiles without errors
- [ ] All tests have been run and passed locally
- [ ] Changes have been documented